### PR TITLE
and changed domain again

### DIFF
--- a/node_modules/buienradar/lib/buienradar.js
+++ b/node_modules/buienradar/lib/buienradar.js
@@ -88,11 +88,11 @@ Buienradar.rainIndicators = {
 				reject(new Error('Location is not set properly, please check location settings and try again.'));
 			}
 
-			console.log('requesting data from', `gadgets.buienradar.nl/data/raintext?lat=${this.lat}&lon=${this.lon}`);
+			console.log('requesting data from', `gps.buienradar.nl/getrr.php?lat=${this.lat}&lon=${this.lon}`);
 			const req = http.request(
 				{
-					host: 'gadgets.buienradar.nl',
-					path: `/data/raintext?lat=${this.lat}&lon=${this.lon}`
+					host: 'gps.buienradar.nl',
+					path: `/getrr.php?lat=${this.lat}&lon=${this.lon}`
 				},
 				(response) => {
 					let data = '';


### PR DESCRIPTION
https://www.buienradar.nl/overbuienradar/gratis-weerdata
[Update 20 juli 2017]: Afgelopen dagen gaf deze widget geen data door. Dit is inmiddels verbeterd. Gebruik hiervoor de url https://gps.buienradar.nl/getrr.php?lat=51&lon=3 en niet de onderliggende url.